### PR TITLE
Use latest dotenv, allow more configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ console.log(config)
 
 ## API
 
-### `transenv(env?)(fn({str, num, bool}))`
+### `transenv({env, path, debug, encoding} = {})(fn({str, num, bool}))`
 The optional argument `env` can be used in a place of `process.env`. If the `env` is not specified and the `NODE_ENV` is not set to the `"production"`, the `.env` file is loaded and merged with the actual `process.env` content. The content of `.env` is ignored in the production mode (`NODE_ENV==="production"`).
+
+Other parameters are [dotenv options](https://github.com/motdotla/dotenv#options) and will be propagated.
 
 The return value of `transenv(env?)` is a transformation function providing `fn` with helpers `{str, num, bool}`. The result of calling `transenv(env)(fn)` is the `fn({str, num, bool})`.
 

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   "license": "Unlicense",
   "scripts": {
     "eslint": "eslint src/**/*.js",
-    "build": "babel src/index.js -o dist/transenv.js",
+    "build": "mkdir --parents dist && babel src/index.js -o dist/transenv.js",
     "prepublish": "yarn run build"
   },
   "dependencies": {
-    "dotenv": "^2.0.0"
+    "dotenv": "^8.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
 import dotenv from 'dotenv'
 
-export default (env) => {
+export default ({env, path, debug, encoding} = {}) => {
   if (env == null) {
-    if (process.env['NODE_ENV'] !== 'production') dotenv.config({silent: true})
+    if (process.env['NODE_ENV'] !== 'production') {
+      dotenv.config({path, debug, encoding})
+    }
     env = process.env
   }
 
@@ -22,7 +24,7 @@ export default (env) => {
   }
 
   const _str2bool = (str, key) => {
-    const val = {'true': true, 'false': false}[str]
+    const val = {true: true, false: false}[str]
     if (val == null) {
       errors.push(`Boolean ${key} has non-boolean value: ${str}.`)
     } else return val
@@ -36,5 +38,4 @@ export default (env) => {
     if (errors.length > 0) throw new Error(errors.join('\n'))
     else return result
   }
-
 }


### PR DESCRIPTION
For migration of fine tracker I need to be able to configure the location of `.env` file.